### PR TITLE
do not mutate inputData parameter

### DIFF
--- a/build/grouped-bar-chart.js
+++ b/build/grouped-bar-chart.js
@@ -1,13 +1,14 @@
-// https://github.com/micahstubbs/grouped-bar-chart#readme Version 0.1.1. Copyright 2016 undefined.
+// https://github.com/micahstubbs/grouped-bar-chart#readme Version 0.1.2. Copyright 2016 undefined.
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('d3')) :
-  typeof define === 'function' && define.amd ? define(['exports', 'd3'], factory) :
-  (factory((global.d3 = global.d3 || {}),global.d3));
-}(this, function (exports,d3) { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('d3'), require('lodash')) :
+  typeof define === 'function' && define.amd ? define(['exports', 'd3', 'lodash'], factory) :
+  (factory((global.d3 = global.d3 || {}),global.d3,global._));
+}(this, function (exports,d3,_) { 'use strict';
 
   d3 = 'default' in d3 ? d3['default'] : d3;
+  _ = 'default' in _ ? _['default'] : _;
 
-  function plot (selector, data, options) {
+  function plot (selector, inputData, options) {
     // set default configuration
     const cfg = {
       margin: { top: 0, right: 0, bottom: 0, left: 0 },
@@ -53,6 +54,7 @@
       .append('g')
         .attr('transform', `translate(${margin.left}, ${margin.top})`);
 
+    let data = _.cloneDeep(inputData);
     const labels = d3.keys(data[0]).filter(key => key !== groupByVariable);
 
     data.forEach(d => {

--- a/build/grouped-bar-chart.js
+++ b/build/grouped-bar-chart.js
@@ -1,4 +1,4 @@
-// https://github.com/micahstubbs/grouped-bar-chart#readme Version 0.1.2. Copyright 2016 undefined.
+// https://github.com/micahstubbs/grouped-bar-chart#readme Version 0.1.3. Copyright 2016 undefined.
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('d3'), require('lodash')) :
   typeof define === 'function' && define.amd ? define(['exports', 'd3', 'lodash'], factory) :

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "grouped-bar-chart",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "a grouped bar chart",
   "main": "build/grouped-bar-chart.js",
   "scripts": {
-    "prepublish": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -f umd -g d3:d3 -n d3 -o build/grouped-bar-chart.js -- index.js",
+    "prepublish": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -f umd -g d3:d3,lodash:_ -n d3 -o build/grouped-bar-chart.js -- index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint index.js src"
   },
@@ -44,6 +44,7 @@
     "rollup": "0.33"
   },
   "dependencies": {
-    "d3": "^3.5.17"
+    "d3": "^3.5.17",
+    "lodash": "^4.13.1"
   }
 }

--- a/src/plot.js
+++ b/src/plot.js
@@ -1,6 +1,7 @@
 import d3 from 'd3';
+import _ from 'lodash';
 
-export default function (selector, data, options) {
+export default function (selector, inputData, options) {
   // set default configuration
   const cfg = {
     margin: { top: 0, right: 0, bottom: 0, left: 0 },
@@ -46,6 +47,7 @@ export default function (selector, data, options) {
     .append('g')
       .attr('transform', `translate(${margin.left}, ${margin.top})`);
 
+  let data = _.cloneDeep(inputData);
   const labels = d3.keys(data[0]).filter(key => key !== groupByVariable);
 
   data.forEach(d => {


### PR DESCRIPTION
this will resolve an error #1  that appears in React Apps when you leave a page with grouped bar charts, then return and try to render the grouped bar charts again.

this PR adds [lodash](https://lodash.com/) as a dependency for its nice [`_.cloneDeep()`](https://lodash.com/docs#cloneDeep) function
