### PR TITLE
viewBox SVG scaling

### DIFF
--- a/build/grouped-bar-chart.js
+++ b/build/grouped-bar-chart.js
@@ -30,10 +30,44 @@
     }
 
     const margin = cfg.margin;
-    const width = cfg.baseWidth - margin.left - margin.right;
-    const height = cfg.baseHeight - margin.top - margin.bottom;
+    // const width = cfg.baseWidth - margin.left - margin.right;
+    // const height = cfg.baseHeight - margin.top - margin.bottom;
     const groupByVariable = cfg.groupByVariable;
     const barColors = cfg.barColors;
+
+    // use these dimensions for the parent SVG
+    const innerWidth = cfg.baseWidth;
+    const innerHeight = cfg.baseHeight;
+
+    let svgWidth;
+    if (String(innerWidth).indexOf('%') > -1) {
+      svgWidth = innerWidth;
+    }
+    else {
+      svgWidth = innerWidth + margin.left + margin.right
+    }
+
+    let svgHeight;
+    if (String(innerHeight).indexOf('%') > -1) {
+      svgHeight = innerHeight;
+    }
+    else {
+      svgHeight = innerHeight + margin.top + margin.bottom
+    }
+
+    const svg = d3.select(selector).append('svg')
+      .attr('width', svgWidth)
+      .attr('height', svgHeight)
+      .attr('viewBox', '0 0 100 100')
+      .attr('preserveAspectRatio', 'none')
+      .append('g')
+        .attr('transform', `translate(${margin.left}, ${margin.top})`);
+
+    // use these dimensions for everything else
+    // and know that they will be SVG-scaled
+    // since we set the viewBox attribute
+    const width = 100;
+    const height = 100;
 
     // console.log(`width ${width} height ${height}`);
 
@@ -47,12 +81,6 @@
 
     const color = d3.scale.ordinal()
       .range(barColors);
-
-    const svg = d3.select(selector).append('svg')
-      .attr('width', width + margin.left + margin.right)
-      .attr('height', height + margin.top + margin.bottom)
-      .append('g')
-        .attr('transform', `translate(${margin.left}, ${margin.top})`);
 
     let data = _.cloneDeep(inputData);
     const labels = d3.keys(data[0]).filter(key => key !== groupByVariable);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grouped-bar-chart",
-  "version": "0.1.3",
+  "version": "0.2.3",
   "description": "a grouped bar chart",
   "main": "build/grouped-bar-chart.js",
   "scripts": {

--- a/src/plot.js
+++ b/src/plot.js
@@ -1,3 +1,4 @@
+
 import d3 from 'd3';
 import _ from 'lodash';
 
@@ -23,10 +24,44 @@ export default function (selector, inputData, options) {
   }
 
   const margin = cfg.margin;
-  const width = cfg.baseWidth - margin.left - margin.right;
-  const height = cfg.baseHeight - margin.top - margin.bottom;
+  // const width = cfg.baseWidth - margin.left - margin.right;
+  // const height = cfg.baseHeight - margin.top - margin.bottom;
   const groupByVariable = cfg.groupByVariable;
   const barColors = cfg.barColors;
+
+  // use these dimensions for the parent SVG
+  const innerWidth = cfg.baseWidth;
+  const innerHeight = cfg.baseHeight;
+
+  let svgWidth;
+  if (String(innerWidth).indexOf('%') > -1) {
+    svgWidth = innerWidth;
+  }
+  else {
+    svgWidth = innerWidth + margin.left + margin.right
+  }
+
+  let svgHeight;
+  if (String(innerHeight).indexOf('%') > -1) {
+    svgHeight = innerHeight;
+  }
+  else {
+    svgHeight = innerHeight + margin.top + margin.bottom
+  }
+
+  const svg = d3.select(selector).append('svg')
+    .attr('width', svgWidth)
+    .attr('height', svgHeight)
+    .attr('viewBox', '0 0 100 100')
+    .attr('preserveAspectRatio', 'none')
+    .append('g')
+      .attr('transform', `translate(${margin.left}, ${margin.top})`);
+
+  // use these dimensions for everything else
+  // and know that they will be SVG-scaled
+  // since we set the viewBox attribute
+  const width = 100;
+  const height = 100;
 
   // console.log(`width ${width} height ${height}`);
 
@@ -40,12 +75,6 @@ export default function (selector, inputData, options) {
 
   const color = d3.scale.ordinal()
     .range(barColors);
-
-  const svg = d3.select(selector).append('svg')
-    .attr('width', width + margin.left + margin.right)
-    .attr('height', height + margin.top + margin.bottom)
-    .append('g')
-      .attr('transform', `translate(${margin.left}, ${margin.top})`);
 
   let data = _.cloneDeep(inputData);
   const labels = d3.keys(data[0]).filter(key => key !== groupByVariable);


### PR DESCRIPTION
This PR makes it possible to specify `baseWidth` and `baseHeight` in % with respect to the parent element

```
  const groupedBarChartOptions = {
    'baseWidth': '100%',
    'baseHeight': '100%',
    // ...
  }
```

which for a  `svg` with `width=300` and `height=400` looks like this:
![screen shot 2016-07-25 at 4 50 00 pm](https://cloud.githubusercontent.com/assets/2119400/17121337/d9baad9c-5287-11e6-88e1-1acaf66cc38d.png)
